### PR TITLE
Probably fix website plugin character encoding

### DIFF
--- a/smartbot/utils.py
+++ b/smartbot/utils.py
@@ -69,7 +69,7 @@ def get_website_title(url):
         headers = { "User-Agent": "SmartBot" }
         page = requests.get(url, headers=headers, timeout=5)
         if page.status_code == 200 and page.headers.get("Content-Type", "").startswith("text/html"):
-            tree = lxml.html.fromstring(page.content)
+            tree = lxml.html.fromstring(page.text)
             title = tree.cssselect("title")[0].text_content()
             return title.strip().replace("\n", "").replace("\r", "")
     except requests.exceptions.Timeout:


### PR DESCRIPTION
Use page.text rather than page.content - makes requests figure out the character encoding rather than it using binary and then interpreting that as ISO-8859-1.
