### PR TITLE
Use params keyword argument for requests

### DIFF
--- a/plugins/brfares.py
+++ b/plugins/brfares.py
@@ -11,8 +11,8 @@ class Plugin:
         self.saved_items = {}
         self.up_to = 0
 
-    def get_code(self, req_url, orig_string, headers, stdout):
-        res = requests.get(req_url, headers=headers).json()
+    def get_code(self, req_url, orig_string, headers, payload, stdout):
+        res = requests.get(req_url, headers=headers, params=payload).json()
         if len(res) == 0:
             print("No results for {0}!".format(orig_string), file=stdout)
             return None
@@ -28,26 +28,26 @@ class Plugin:
             station2 = match.group(2)
             rlc = match.group(3) or " " * 3 # three spaces == no railcard
 
-            station_url = "http://api.brfares.com/ac_loc?term={0}"
-            rlc_url = "http://api.brfares.com/ac_rlc?term={0}"
-            query_url = "http://api.brfares.com/querysimple?orig={0}&dest={1}&rlc={2}"
-            restriction_url = "http://www.brfares.com/restrictionspec?code={0}"
+            station_url = "http://api.brfares.com/ac_loc"
+            rlc_url = "http://api.brfares.com/ac_rlc"
+            query_url = "http://api.brfares.com/querysimple"
+            restriction_url = "http://www.brfares.com/restrictionspec"
 
             headers = {"User-Agent": "SmartBot"}
-
-            stn1_req = station_url.format(urllib.parse.quote(station1))
-            stn2_req = station_url.format(urllib.parse.quote(station2))
-            rlc_req = rlc_url.format(urllib.parse.quote(rlc))
             
-            stn1_code = self.get_code(stn1_req, station1, headers, stdout)
-            stn2_code = self.get_code(stn2_req, station2, headers, stdout)
-            rlc_code = self.get_code(rlc_req, rlc, headers, stdout)
+            stn1_code = self.get_code(station_url, station1, headers, {'term': station1}, stdout)
+            stn2_code = self.get_code(station_url, station2, headers, {'term': station2}, stdout)
+            rlc_code = self.get_code(rlc_url, rlc, headers, {'term': rlc}, stdout)
 
             if not stn1_code or not stn2_code or not rlc_code:
                 return
 
-            query_req = query_url.format(stn1_code, stn2_code, rlc_code)
-            fares = requests.get(query_req, headers=headers).json()
+            query_payload = {
+                "orig": stn1_code,
+                "dest": stn2_code,
+                "rlc" : rlc_code,
+            }
+            fares = requests.get(query_url, headers=headers, params=query_payload).json()
             if len(fares["fares"]) == 0:
                 print('No fares from {orig[ticketname]} ({orig[code]}) to {dest[ticketname]} ({dest[code]}) with {railcard[name]} ({railcard[code]})!'.format(**fares), file=stdout)
                 return

--- a/plugins/brfares.py
+++ b/plugins/brfares.py
@@ -35,8 +35,8 @@ class Plugin:
 
             headers = {"User-Agent": "SmartBot"}
             
-            stn1_code = self.get_code(station_url, station1, headers, {'term': station1}, stdout)
-            stn2_code = self.get_code(station_url, station2, headers, {'term': station2}, stdout)
+            stn1_code = self.get_code(station_url, station1, headers, {"term": station1}, stdout)
+            stn2_code = self.get_code(station_url, station2, headers, {"term": station2}, stdout)
             rlc_code = self.get_code(rlc_url, rlc, headers, {'term': rlc}, stdout)
 
             if not stn1_code or not stn2_code or not rlc_code:

--- a/plugins/complete.py
+++ b/plugins/complete.py
@@ -12,10 +12,14 @@ class Plugin:
             query = stdin.read().strip()
 
         if query:
-            url = "http://google.com/complete/search?q={0}&output=toolbar".format(urllib.parse.quote(query))
+            url = "http://google.com/complete/search"
             headers = {"User-Agent": "SmartBot"}
+            payload = {
+                "q": query,
+                "output": "toolbar",
+            }
 
-            page = requests.get(url, headers=headers)
+            page = requests.get(url, headers=headers, params=payload)
             tree = lxml.etree.fromstring(page.text)
 
             suggestions = []

--- a/plugins/define.py
+++ b/plugins/define.py
@@ -11,10 +11,14 @@ class Plugin:
             topic = stdin.read().strip()
 
         if topic:
-            url = "http://api.duckduckgo.com/?format=json&q={0}".format(urllib.parse.quote(topic))
+            url = "http://api.duckduckgo.com/"
             headers = {"User-Agent": "SmartBot"}
+            payload = {
+                "q": topic,
+                "format": "json",
+            }
 
-            res = requests.get(url, headers=headers).json()
+            res = requests.get(url, headers=headers, params=payload).json()
             if res.get("AbstractText"):
                 print(res["AbstractText"], file=stdout)
                 if res.get("AbstractURL"):

--- a/plugins/google.py
+++ b/plugins/google.py
@@ -18,14 +18,16 @@ class Plugin:
             query = stdin.read().strip()
 
         if query:
-            url = "https://www.googleapis.com/customsearch/v1?key={0}&cx={1}&q={2}&num=5".format(
-                urllib.parse.quote(self.key),
-                urllib.parse.quote(self.cx),
-                urllib.parse.quote(query)
-            )
+            url = "https://www.googleapis.com/customsearch/v1"
             headers = {"User-Agent": "SmartBot"}
+            payload = {
+                "key": self.key,
+                "cx" : self.cx,
+                "q": query,
+                "num": 5,
+            }
 
-            res = requests.get(url, headers=headers).json()
+            res = requests.get(url, headers=headers, params=payload).json()
             if "error" in res:
                 print(res["error"]["message"], file=stdout)
             elif "items" in res:

--- a/plugins/news.py
+++ b/plugins/news.py
@@ -10,20 +10,22 @@ class Plugin:
         if not topic:
             topic = stdin.read().strip()
 
-        if topic:
-            url = "https://ajax.googleapis.com/ajax/services/search/news?v=1.0&rsz=5&q={0}".format(
-                urllib.parse.quote(topic)
-            )
-        else:
-            url = "https://ajax.googleapis.com/ajax/services/search/news?v=1.0&rsz=5&topic=h"
-
+        url = "https://ajax.googleapis.com/ajax/services/search/news"
         headers = {"User-Agent": "SmartBot"}
+        payload = {
+            "v": "1.0",
+            "rsz": "5",
+        }
+        if topic:
+            payload["q"] = topic
+        else:
+            payload["topic"] = "h"
 
-        res = requests.get(url, headers=headers).json()
+        res = requests.get(url, headers=headers, params=payload).json()
         stories = res["responseData"]["results"][:3]
         if stories:
             for i, story in enumerate(stories):
-                title = story["titleNoFormatting"].replace("&#39;", "'").replace("`", "'").replace("&quot;", "\"")
+                title = story["titleNoFormatting"].replace("&#39;", """).replace("`", """).replace("&quot;", "\"")
                 link = story["unescapedUrl"]
                 print("[{0}]: {1} - {2}".format(i, title, link), file=stdout)
         else:

--- a/plugins/news.py
+++ b/plugins/news.py
@@ -25,7 +25,7 @@ class Plugin:
         stories = res["responseData"]["results"][:3]
         if stories:
             for i, story in enumerate(stories):
-                title = story["titleNoFormatting"].replace("&#39;", """).replace("`", """).replace("&quot;", "\"")
+                title = story["titleNoFormatting"].replace("&#39;", "'").replace("`", "'").replace("&quot;", "\"")
                 link = story["unescapedUrl"]
                 print("[{0}]: {1} - {2}".format(i, title, link), file=stdout)
         else:

--- a/plugins/trains.py
+++ b/plugins/trains.py
@@ -7,13 +7,15 @@ import urllib.parse
 class Plugin:
     def on_command(self, bot, msg, stdin, stdout, reply):
         if len(msg["args"]) >= 3:
-            url = "http://ojp.nationalrail.co.uk/service/ldb/liveTrainsJson?departing=true&liveTrainsFrom={0}&liveTrainsTo={1}".format(
-                urllib.parse.quote(msg["args"][1]),
-                urllib.parse.quote(msg["args"][2])
-            )
+            url = "http://ojp.nationalrail.co.uk/service/ldb/liveTrainsJson"
             headers = {"User-Agent": "SmartBot"}
+            payload = {
+                "liveTrainsFrom": msg["args"][1],
+                "liveTrainsTo"  : msg["args"][2],
+                "departing": "true",
+            }
 
-            res = requests.get(url, headers=headers).json()
+            res = requests.get(url, headers=headers, params=payload).json()
             if res["trains"]:
                 for i, train in enumerate(res["trains"]):
                     if train[4]:

--- a/plugins/wolfram.py
+++ b/plugins/wolfram.py
@@ -83,13 +83,14 @@ class Plugin:
             query = stdin.read().strip()
 
         if query:
-            url = "http://api.wolframalpha.com/v2/query?input={0}&appid={1}".format(
-                urllib.parse.quote(query),
-                urllib.parse.quote(self.appid)
-            )
+            url = "http://api.wolframalpha.com/v2/query"
             headers = {"User-Agent": "SmartBot"}
+            payload = {
+                "input": query,
+                "appid": self.appid,
+            }
 
-            page = requests.get(url, headers=headers, timeout=15)
+            page = requests.get(url, headers=headers, params=payload, timeout=15)
             if page.status_code == 200:
                 tree = lxml.etree.fromstring(page.content)
                 pods = []

--- a/plugins/youtube.py
+++ b/plugins/youtube.py
@@ -18,6 +18,11 @@ class Plugin:
                 urllib.parse.quote(id)
             )
             headers = {"User-Agent": "SmartBot"}
+            payload = {
+                "key": self.key,
+                "id": id,
+                "part": ",".join(["contentDetails", "snippet", "statistics"]),
+            }
 
             res = requests.get(url, headers=headers).json()
             if res["items"]:


### PR DESCRIPTION
It is better style to pass url parameters such as in `http://example.tld/?foo=bar&baz=...` to the params argument of `requests`. This keeps the `url`s cleaner and removes the need of formatting with `urllib`-escaped strings, as `requests` will handle all that on its own.
